### PR TITLE
Use PSDepend to install modules

### DIFF
--- a/FullModuleTemplate/.gitignore
+++ b/FullModuleTemplate/.gitignore
@@ -1,1 +1,2 @@
 /output/
+/_build-cache/

--- a/FullModuleTemplate/PlasterManifest.xml
+++ b/FullModuleTemplate/PlasterManifest.xml
@@ -31,8 +31,10 @@
     <file source='' destination='${PLASTER_PARAM_ModuleName}\data'/>
     <message>      Deploying files    </message>
     <file source='appveyor.yml' destination=''/>
+    <file source='build.depend.psd1' destination=''/>
     <file source='build.ps1' destination=''/>
     <file source='deploy.PSDeploy.ps1' destination=''/>
+    <file source='test.depend.psd1' destination=''/>
     <file source='.gitignore' destination=''/>
     <file source='.vscode\settings.json' destination=''/>
     <file source='spec\module.Steps.ps1' destination=''/>

--- a/FullModuleTemplate/build.depend.psd1
+++ b/FullModuleTemplate/build.depend.psd1
@@ -1,0 +1,13 @@
+@{ 
+    PSDependOptions  = @{ 
+        Target    = '$DependencyPath/_build-cache/'
+        AddToPath = $true
+    }
+    InvokeBuild      = '4.1.0'
+    PSDeploy         = '0.2.2'
+    BuildHelpers     = '0.0.53'
+    PSScriptAnalyzer = '1.16.1'
+    Pester           = @{
+        Version = '4.1.0'
+    }
+}

--- a/FullModuleTemplate/test.depend.psd1
+++ b/FullModuleTemplate/test.depend.psd1
@@ -1,0 +1,9 @@
+@{ 
+    PSDependOptions = @{ 
+        Target    = '$DependencyPath/_build-cache/'
+        AddToPath = $true
+    }
+    # Add the *exact versions* of any dependencies of your module...
+    # EG:
+    # IISAdministration   = '1.1.0.0'
+}


### PR DESCRIPTION
Currently multiple projects running on the same machine interfere with each other by installing different versions dependent modules.

A build should be repeatable. This can only be if exact versions of dependent modules installed.

Using PSDepend we create an isolated build/test per project and get to nicely specify versions