### PR TITLE
Support Pester running against "compiled" module or source code.

### DIFF
--- a/FullModuleTemplate/build.ps1
+++ b/FullModuleTemplate/build.ps1
@@ -29,6 +29,7 @@ Write-Output "    SUT Modules"
 Invoke-PSDepend -Path "$PSScriptRoot\test.depend.psd1" -Install -Import -Force
 
 Set-BuildEnvironment
+$global:SUTPath = $env:BHPSModuleManifest
 
 Write-Output "  InvokeBuild"
 Invoke-Build $Task -Result result

--- a/FullModuleTemplate/module.build.ps1
+++ b/FullModuleTemplate/module.build.ps1
@@ -7,6 +7,7 @@ $script:ModulePath = "$Destination\$ModuleName.psm1"
 $script:ManifestPath = "$Destination\$ModuleName.psd1"
 $script:Imports = ( 'private', 'public', 'classes' )
 $script:TestFile = "$PSScriptRoot\output\TestResults_PS$PSVersion`_$TimeStamp.xml"
+$global:SUTPath = $script:ManifestPath
 
 Task Default Build, Pester, UpdateSource, Publish
 Task Build CopyToOutput, BuildPSM1, BuildPSD1

--- a/FullModuleTemplate/tests/Feature.Tests.ps1
+++ b/FullModuleTemplate/tests/Feature.Tests.ps1
@@ -1,6 +1,7 @@
-$projectRoot = Resolve-Path "$PSScriptRoot\.."
-$script:ModuleName = '<%= $PLASTER_PARAM_ModuleName %>'
-
 Describe "Basic function feature tests" -Tags Build {
 
+    BeforeAll {
+        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Import-Module ($global:SUTPath)
+    }
 }

--- a/FullModuleTemplate/tests/Help.Tests.ps1
+++ b/FullModuleTemplate/tests/Help.Tests.ps1
@@ -1,7 +1,11 @@
-$projectRoot = Resolve-Path "$PSScriptRoot\.."
-$script:ModuleName = '<%= $PLASTER_PARAM_ModuleName %>'
+$moduleName = $env:BHProjectName
 
 Describe "Help tests for $moduleName" -Tags Build {
+
+    BeforeAll {
+        Get-Module $moduleName -All | Remove-Module
+        Import-Module ($global:SUTPath)
+    }
 
     $functions = Get-Command -Module $moduleName
     $help = $functions | % {Get-Help $_.name}

--- a/FullModuleTemplate/tests/Project.Tests.ps1
+++ b/FullModuleTemplate/tests/Project.Tests.ps1
@@ -1,6 +1,5 @@
-$projectRoot = Resolve-Path "$PSScriptRoot\.."
-$script:ModuleName = '<%= $PLASTER_PARAM_ModuleName %>'
-$moduleRoot = "$projectRoot\$ModuleName"
+$script:ModuleName = $env:BHProjectName
+$moduleRoot = $env:BHModulePath
 
 Describe "PSScriptAnalyzer rule-sets" -Tag Build {
 
@@ -26,6 +25,6 @@ Describe "PSScriptAnalyzer rule-sets" -Tag Build {
 Describe "General project validation: $moduleName" -Tags Build {
 
     It "Module '$moduleName' can import cleanly" {
-        {Import-Module (Join-Path $moduleRoot "$moduleName.psm1") -force } | Should Not Throw
+        {Import-Module ($global:SUTPath) -force } | Should Not Throw
     }
 }

--- a/FullModuleTemplate/tests/Regression.Tests.ps1
+++ b/FullModuleTemplate/tests/Regression.Tests.ps1
@@ -1,7 +1,9 @@
-$projectRoot = Resolve-Path "$PSScriptRoot\.."
-$script:ModuleName = '<%= $PLASTER_PARAM_ModuleName %>'
-
 Describe "Regression tests" -Tag Build {
+
+    BeforeAll {
+        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Import-Module ($global:SUTPath)
+    }
 
     Context "Github Issues" {
        

--- a/FullModuleTemplate/tests/Unit.Tests.ps1
+++ b/FullModuleTemplate/tests/Unit.Tests.ps1
@@ -1,6 +1,6 @@
-$projectRoot = Resolve-Path "$PSScriptRoot\.."
-$script:ModuleName = '<%= $PLASTER_PARAM_ModuleName %>'
-
 Describe "Basic function unit tests" -Tags Build {
-
+    BeforeAll {
+        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Import-Module ($global:SUTPath)
+    }
 }


### PR DESCRIPTION
The quickest feedback cycle is running Pester *directly* without
having to run the build first.

Also `build.ps1` adds a degree of friction to someone already
familar with Pester - she now has to discover our project
conventions.

Yet, when it comes to the CI build you always want to be testing
against the "compiled" module output.

A project template should support both CI and developer
preferences.