### PR TITLE
Fix: module *dependencies* should be removed on cleanup

### DIFF
--- a/FullModuleTemplate/build.ps1
+++ b/FullModuleTemplate/build.ps1
@@ -40,6 +40,7 @@ if (-not (Get-Item env:\BH*))
     Set-BuildEnvironment
 }
 $global:SUTPath = $env:BHPSModuleManifest
+. "$PSScriptRoot\tests\Unload-SUT.ps1"
 
 if ($Task -eq 'init') 
 {

--- a/FullModuleTemplate/tests/Feature.Tests.ps1
+++ b/FullModuleTemplate/tests/Feature.Tests.ps1
@@ -1,7 +1,11 @@
 Describe "Basic function feature tests" -Tags Build {
 
     BeforeAll {
-        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Unload-SUT
         Import-Module ($global:SUTPath)
+    }
+
+    AfterAll {
+        Unload-SUT
     }
 }

--- a/FullModuleTemplate/tests/Help.Tests.ps1
+++ b/FullModuleTemplate/tests/Help.Tests.ps1
@@ -3,8 +3,12 @@ $moduleName = $env:BHProjectName
 Describe "Help tests for $moduleName" -Tags Build {
 
     BeforeAll {
-        Get-Module $moduleName -All | Remove-Module
+        Unload-SUT
         Import-Module ($global:SUTPath)
+    }
+
+    AfterAll {
+        Unload-SUT
     }
 
     $functions = Get-Command -Module $moduleName

--- a/FullModuleTemplate/tests/Project.Tests.ps1
+++ b/FullModuleTemplate/tests/Project.Tests.ps1
@@ -24,6 +24,10 @@ Describe "PSScriptAnalyzer rule-sets" -Tag Build {
 
 Describe "General project validation: $moduleName" -Tags Build {
 
+    AfterAll {
+        Unload-SUT
+    }
+
     It "Module '$moduleName' can import cleanly" {
         {Import-Module ($global:SUTPath) -force } | Should Not Throw
     }

--- a/FullModuleTemplate/tests/Regression.Tests.ps1
+++ b/FullModuleTemplate/tests/Regression.Tests.ps1
@@ -1,8 +1,12 @@
 Describe "Regression tests" -Tag Build {
 
     BeforeAll {
-        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Unload-SUT
         Import-Module ($global:SUTPath)
+    }
+
+    AfterAll {
+        Unload-SUT
     }
 
     Context "Github Issues" {

--- a/FullModuleTemplate/tests/Unit.Tests.ps1
+++ b/FullModuleTemplate/tests/Unit.Tests.ps1
@@ -1,6 +1,10 @@
 Describe "Basic function unit tests" -Tags Build {
     BeforeAll {
-        Get-Module ($env:BHProjectName) -All | Remove-Module
+        Unload-SUT
         Import-Module ($global:SUTPath)
+    }
+
+    AfterAll {
+        Unload-SUT
     }
 }

--- a/FullModuleTemplate/tests/Unload-SUT.ps1
+++ b/FullModuleTemplate/tests/Unload-SUT.ps1
@@ -1,0 +1,8 @@
+function global:Unload-SUT
+{
+    $modulesToUnload = @(Get-Dependency -Path "$PSScriptRoot\..\test.depend.psd1" |
+            Where-Object DependencyType -eq PSGalleryModule | 
+            Select-Object -Exp DependencyName)
+    $modulesToUnload += $env:BHProjectName
+    $modulesToUnload | Get-Module -All | Remove-Module -Force -EA Ignore
+}


### PR DESCRIPTION
## New `Unload-SUT` function

Cleanup logic should remove not only the module built/tested but
also any dependent modules. Not doing so can result in failures
when PS tries to load multiple instances of a module (eg when that
module exposes types).

`test.depend.psd1` defines all dependencies of the SUT.
A new `Unload-SUT` function uses this to generically unload all
modules necessary.

## Cleanup *after* all testcases

Is best practice that after a test run, to cleanup by removing SUT modules. This is achieved by adding an `AfterAll` code block
to each test file

## Cleanup module.build.ps1

Now that loading/unloading is handled by each test, the
ImportModule task is no longer necessarily