### PR TITLE
Exclude PSScriptAnalyzer rule that always fails

### DIFF
--- a/FullModuleTemplate/tests/Project.Tests.ps1
+++ b/FullModuleTemplate/tests/Project.Tests.ps1
@@ -3,7 +3,8 @@ $moduleRoot = $env:BHModulePath
 
 Describe "PSScriptAnalyzer rule-sets" -Tag Build {
 
-    $Rules = Get-ScriptAnalyzerRule
+    $rulesToExclude = @('PSUseToExportFieldsInManifest')
+    $Rules = Get-ScriptAnalyzerRule | where RuleName -NotIn $rulesToExclude
     $scripts = Get-ChildItem $moduleRoot -Include *.ps1, *.psm1, *.psd1 -Recurse | where fullname -notmatch 'classes'
 
     foreach ( $Script in $scripts ) 


### PR DESCRIPTION
The build replaces `FunctionsToExport = '*'` with
the list of function names.

However, this PSScriptAnalyzer runs on source code *prior*
to this replacement and therefore detects a broken rule