### PR TITLE
Default vscode PSScriptAnalyzer rules

### DIFF
--- a/FullModuleTemplate/.vscode/PSScriptAnalyzerSettings.psd1
+++ b/FullModuleTemplate/.vscode/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,28 @@
+# The PowerShell Script Analyzer will generate a warning
+# diagnostic record for this file due to a bug -
+# https://github.com/PowerShell/PSScriptAnalyzer/issues/472
+@{
+    # Only diagnostic records of the specified severity will be generated.
+    # Uncomment the following line if you only want Errors and Warnings but
+    # not Information diagnostic records.
+    #Severity = @('Error','Warning')
+
+    # Analyze **only** the following rules. Use IncludeRules when you want
+    # to invoke only a small subset of the defualt rules.
+    # IncludeRules = @('PSAvoidDefaultValueSwitchParameter',
+    #                  'PSMisleadingBacktick',
+    #                  'PSMissingModuleManifestField',
+    #                  'PSReservedCmdletChar',
+    #                  'PSReservedParams',
+    #                  'PSShouldProcess',
+    #                  'PSUseApprovedVerbs',
+    #                  'PSAvoidUsingCmdletAliases',
+    #                  'PSUseDeclaredVarsMoreThanAssigments')
+
+    # Do not analyze the following rules. Use ExcludeRules when you have
+    # commented out the IncludeRules settings above and want to include all
+    # the default rules except for those you exclude below.
+    # Note: if a rule is in both IncludeRules and ExcludeRules, the rule
+    # will be excluded.
+    ExcludeRules = @('PSAvoidUsingCmdletAliases', 'PSAvoidGlobalVars')
+}

--- a/FullModuleTemplate/.vscode/settings.json
+++ b/FullModuleTemplate/.vscode/settings.json
@@ -8,5 +8,6 @@
   "editor.tabSize": 4,
   "[json]": {
     "editor.tabSize": 2
-  }
+  },
+  "powershell.scriptAnalysis.settingsPath": ".vscode/PSScriptAnalyzerSettings.psd1"
 }

--- a/FullModuleTemplate/PlasterManifest.xml
+++ b/FullModuleTemplate/PlasterManifest.xml
@@ -38,6 +38,7 @@
     <file source='test.depend.psd1' destination=''/>
     <file source='.gitignore' destination=''/>
     <file source='.vscode\launch.json' destination=''/>
+	<file source='.vscode\PSScriptAnalyzerSettings.psd1' destination=''/>
     <file source='.vscode\settings.json' destination=''/>
     <file source='spec\module.Steps.ps1' destination=''/>
     <templateFile source='mkdocs.yml' destination=''/>


### PR DESCRIPTION
We want different rules depending on whether we're coding tests or the SUT. For example in test code global variables make sense. That is not the case for production code.

When in vscode we don't want it complaining so we need exclude specific rules.

We have the project.test to keep to check our production code.