### PR TITLE
Update to latest PSDepend + fix install of PSDepend

### DIFF
--- a/FullModuleTemplate/build.ps1
+++ b/FullModuleTemplate/build.ps1
@@ -24,10 +24,10 @@ if (-not (Get-PackageProvider -Name Nuget -EA SilentlyContinue))
 # Grab nuget bits, install modules, set build variables, start build.
 Write-Output "  Install And Import Dependent Modules"
 Write-Output "    Build Modules"
-$psDependVersion = '0.1.58'
+$psDependVersion = '0.1.62'
 if (-not(Get-InstalledModule PSDepend -RequiredVersion $psDependVersion -EA SilentlyContinue))
 {
-    Install-Module PSDepend -RequiredVersion $psDependVersion -Scope CurrentUser
+    Install-Module PSDepend -RequiredVersion $psDependVersion -Force -Scope CurrentUser
 }
 Import-Module PSDepend -RequiredVersion $psDependVersion
 Invoke-PSDepend -Path "$PSScriptRoot\build.depend.psd1" -Install -Import -Force


### PR DESCRIPTION
On CI servers, PSGallery will be untrusted. This causes install of PSDepend to fail.

PSDepend v0.1.62 includes important fix:
https://github.com/RamblingCookieMonster/PSDepend/pull/61