### PR TITLE
fix: appveyor should use more expicit settings

### DIFF
--- a/FullModuleTemplate/PlasterManifest.xml
+++ b/FullModuleTemplate/PlasterManifest.xml
@@ -31,7 +31,7 @@
     <file source='' destination='${PLASTER_PARAM_ModuleName}\data'/>
     <message>      Deploying files    </message>
     <file source='.vsts-ci.yml' destination=''/>
-    <file source='appveyor.yml' destination=''/>
+    <templateFile source='appveyor.yml' destination=''/>
     <file source='build.depend.psd1' destination=''/>
     <file source='build.ps1' destination=''/>
     <file source='deploy.PSDeploy.ps1' destination=''/>

--- a/FullModuleTemplate/appveyor.yml
+++ b/FullModuleTemplate/appveyor.yml
@@ -1,5 +1,11 @@
 # See http://www.appveyor.com/docs/appveyor-yml for many more options
 
+# Build worker image (VM template)
+image: Visual Studio 2015
+
+# clone directory
+clone_folder: C:\MyProjects\<%= $PLASTER_PARAM_ModuleName %>
+
 environment:
   NugetApiKey:
     secure: ***************


### PR DESCRIPTION
* the default git clone directory uses lower case path
  * this can results in duplicate modules publishing to myget
* appveyor base image might change which destroys repeatability